### PR TITLE
Encode buffer contents as base64 instead of integer array

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,12 +2,7 @@ module.exports = function(content) {
   this.cacheable && this.cacheable();
   this.value = content;
 
-  var array = new Array();
-  for (var i = 0; i != content.length; ++i) {
-    array[i] = content[i];
-  }
-
-  return 'module.exports = new Buffer(' + JSON.stringify(array) + ')';
+  return 'module.exports = new Buffer("' + content.toString('base64') + '", "base64")';
 };
 
 module.exports.raw = true;

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ module.exports = function(content) {
   this.cacheable && this.cacheable();
   this.value = content;
 
-  return 'module.exports = new Buffer("' + content.toString('base64') + '", "base64")';
+  return 'module.exports = Buffer.from("' + content.toString('base64') + '", "base64")';
 };
 
 module.exports.raw = true;


### PR DESCRIPTION
base64 is more than twice as compact as the current integer array representation, and can easily be loaded by the Buffer implementation on the target.

Here are the results of a quick test I made bundling a 1000000-byte file from `/dev/random`:

|                    |integer array|base64 string|
|----------|-------------|-------------|
|bundle size |  3593179  | 1356324 | 
|gzipped       |  1322017 | 1018119 |
